### PR TITLE
ログインしてない時に、コンテスト一覧が認証エラーで取得できないバグを修正。

### DIFF
--- a/src/api/index.js
+++ b/src/api/index.js
@@ -60,8 +60,8 @@ export default {
     const res = await axios.get(`${API_ENDPOINT}/contests/${contestID}`, getConfig(sessionID));
     return res;
   },
-  async getContests(sessionID) {
-    const res = await axios.get(`${API_ENDPOINT}/contests`, getConfig(sessionID));
+  async getContests() {
+    const res = await axios.get(`${API_ENDPOINT}/contests`);
     return res;
   },
   async getContestProblems(sessionID, contestID) {

--- a/src/store/modules/contest-list.js
+++ b/src/store/modules/contest-list.js
@@ -45,9 +45,9 @@ export default {
     },
   },
   actions: {
-    async fetchAllContests({ commit, rootState }) {
+    async fetchAllContests({ commit }) {
       try {
-        const res = await api.getContests(rootState.koneko.sessionID);
+        const res = await api.getContests();
         commit('setContests', res.data);
         commit('setError', null);
       } catch (e) {


### PR DESCRIPTION
変なAuthorizationヘッダーを送信すると401になってしまうので、ログイン不要のエンドポイントにはgetConfig(sessionID)とかしないほうが良さそう(apiが悪い)